### PR TITLE
Allow running te docker image as non root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### docs:
 - updated the Development documentations
 
+### features:
+- Allow this image to be ran under a non-root user in /app directory. (@stijndehaes)
+
 ## [0.2.0 - 2020-09-09]
 
 ### features:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,8 @@ FROM python
 COPY requirements.txt requirements.txt
 
 RUN pip3 install -r requirements.txt --no-cache-dir
+
+RUN mkdir /app && chmod 777 /app
+COPY cookiecutter.yml /app/cookiecutter.yml
+ENV COOKIECUTTER_CONFIG=/app/cookiecutter.yml
+WORKDIR /app

--- a/cookiecutter.yml
+++ b/cookiecutter.yml
@@ -1,0 +1,1 @@
+replay_dir: "/app/replay"


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Allow running te docker image as non root user

We do this by creating a folder that is globally owned
and can be used to create the template in. We also make
sure the cookiecutter replay folder is in this directory
so that it can always be created.


## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->

If you use the container to generate a template the files generated are owned by root this is a problem on linux.
So we need to be able to run this container as non root.


## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Manually with docker run