### PR TITLE
Fix spark 2.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### bugfixes:
+- Fix spark 2.4 support for the pyspark template. Pip3 binary did not exist so created a symlink to the pip3.6 binary to fix this (@stijndehaes)
+
 ## [0.2.1 - 2020-09-17]
 
 ### docs:

--- a/project/pyspark/{{ cookiecutter.project_name }}/Dockerfile
+++ b/project/pyspark/{{ cookiecutter.project_name }}/Dockerfile
@@ -1,5 +1,6 @@
 {% if cookiecutter.spark_version == "2.4" -%}
 FROM datamindedbe/spark-k8s-glue:2.4.3-2.12-hadoop-2.9.2-v2
+RUN rm -rf /usr/bin/pip && ln -s /usr/bin/pip3.6 /usr/bin/pip && ln -s /usr/bin/pip3.6 /usr/bin/pip3
 {%- elif cookiecutter.spark_version == "3.0" -%}
 FROM datamindedbe/spark-k8s-glue:3.0.0-hadoop-3.2.1
 {%- endif %}

--- a/tests/projects/test_pyspark.py
+++ b/tests/projects/test_pyspark.py
@@ -1,5 +1,53 @@
+import subprocess
+
+
 def test_pyspark_template(cookies):
     result = cookies.bake(template="project/pyspark", extra_context={})
     assert 0 == result.exit_code
     assert result.exception is None
     assert result.project.isdir()
+
+
+def assert_project_can_be_build(result):
+    assert 0 == result.exit_code
+    process = subprocess.Popen(
+        ["docker", "build", "."],
+        cwd=result.project,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    (
+        stdout,
+        stderr,
+    ) = process.communicate()  # You can use stoud and sterr to find out what went wrong
+    return_code = process.poll()
+    assert return_code == 0, stderr
+
+
+def test_pyspark_template_spark_3(cookies):
+    """
+    This test makes sure that when a project with spark 3 support is being rendered the docker image can be build
+    """
+    result = cookies.bake(
+        template="project/pyspark", extra_context={"spark_version": "3.0"}
+    )
+    assert_project_can_be_build(result)
+
+
+def test_pyspark_template_spark_2_4(cookies):
+    """
+    This test makes sure that when a project with spark 2.4 support is being rendered the docker image can be build
+    """
+    result = cookies.bake(template="project/pyspark", extra_context={})
+    assert_project_can_be_build(result)
+
+
+def test_pyspark_template_spark_pipenv(cookies):
+    """
+    This test makes sure that when a project with pipenv support is being rendered the docker image can be build
+    """
+    result = cookies.bake(
+        template="project/pyspark",
+        extra_context={"python_package_management": "pipenv"},
+    )
+    assert_project_can_be_build(result)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->

Symlinked pip3.6 to pip and pip3 to fix the pyspark 2.4 support.

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->

The rest of the code uses the pip3 binary to install libraries

## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

By adding tests