### PR TITLE
Bugfix/921/dbt template none role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - In python template configure the logging framework. This adds an example on how to change the logging level (@stijndehaes)
 
+### bugfixes:
+- Remove resource in dbt template when role_creation is none (@pascal-knapen)
+
 ## [0.2.2 - 2020-09-24]
 
 ### bugfixes:

--- a/project/dbt/hooks/post_gen_project.py
+++ b/project/dbt/hooks/post_gen_project.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 import os
+import shutil
+
 from dataclasses import dataclass
 
 project_name = "{{ cookiecutter.project_name }}"
+role_creation = "{{ cookiecutter.role_creation }}"
 
 
 @dataclass
@@ -20,13 +23,24 @@ def fix_dbt_project():
 
 def initialize_dbt():
     os.mkdir('dbt')
+    previous_dir = os.getcwd()
     os.chdir('dbt')
-    os.environ["DBT_PROFILES_DIR"] = os.getcwd()
-    import dbt.task.init as init_task  # late import so the environment variable is take into account
-    task = init_task.InitTask(args=InitArguments(project_name), config=None)
-    task.run()
-    fix_dbt_project()
+    try:
+        os.environ["DBT_PROFILES_DIR"] = os.getcwd()
+        import dbt.task.init as init_task  # late import so the environment variable is take into account
+        task = init_task.InitTask(args=InitArguments(project_name), config=None)
+        task.run()
+        fix_dbt_project()
+    finally:
+        os.chdir(previous_dir)
+
+
+def cleanup_resources():
+    if role_creation == "none":
+        shutil.rmtree("resources")
 
 
 if __name__ == "__main__":
     initialize_dbt()
+    cleanup_resources()
+

--- a/tests/projects/test_dbt.py
+++ b/tests/projects/test_dbt.py
@@ -3,3 +3,13 @@ def test_dbt_template(cookies):
     assert 0 == result.exit_code
     assert result.exception is None
     assert result.project.isdir()
+
+
+def test_dbt_template_no_role(cookies):
+    result = cookies.bake(
+        template="project/dbt", extra_context={"role_creation": "none"}
+    )
+    assert 0 == result.exit_code
+    assert result.exception is None
+    assert result.project.isdir()
+    assert not (result.project + "/resources").isdir()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
Remove the resources folder when you don't want to use a role

## Why are the changes needed?
Creating a service account without any need might confuse users

## How was this tested?
Added a test to validate that the resources folder is removed when no role was selected.