### PR TITLE
Pin python version to 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: x64
       - name: Cache python dependencies
         uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### bugfixes:
+- Docker image pin python version to 3.9 (@stijndehaes) 
+
 ## [0.3.0 - 2020-10-09]
 
 ### features:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.8
 
 COPY requirements.txt requirements.txt
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
The dbt template did not work because the python
version in our docker image was automatically
upgraded to 3.9.0. Now pinning the version to
3.8.x.

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->
The dbt template did not work because the python
version in our docker image was automatically
upgraded to 3.9.0. 

## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

By creating the image and using it in the datafy cli