### PR TITLE
Switch images from docker hub to public aws ecr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### features:
+- Change from docker hub images to public ECR images: https://gallery.ecr.aws/dataminded/spark-k8s-glue (@stijndehaes)
+
 ## [0.3.2 - 2020-12-09]
 
 ### features:
-- Upgrade the spark 2.4.3 images to the latest version. This version only includes one version of the aws sdk.
+- Upgrade the spark 2.4.3 images to the latest version. This version only includes one version of the aws sdk. (@stijndehaes)
 
 ### bugfixes:
-- Make sure the generated service account are kubernetes compliant
+- Make sure the generated service account are kubernetes compliant (@stijndehaes)
 
 ## [0.3.1 - 2020-11-06]
 

--- a/project/pyspark/{{ cookiecutter.project_name }}/Dockerfile
+++ b/project/pyspark/{{ cookiecutter.project_name }}/Dockerfile
@@ -1,8 +1,8 @@
 {% if cookiecutter.spark_version == "2.4" -%}
-FROM datamindedbe/spark-k8s-glue:2.4.3-2.11-hadoop-2.9.2-v3
+FROM public.ecr.aws/dataminded/spark-k8s-glue:2.4.3-2.11-hadoop-2.9.2-v3
 RUN rm -rf /usr/bin/pip && ln -s /usr/bin/pip3.6 /usr/bin/pip && ln -s /usr/bin/pip3.6 /usr/bin/pip3
 {%- elif cookiecutter.spark_version == "3.0" -%}
-FROM datamindedbe/spark-k8s-glue:v3.0.1-hadoop-3.3.0
+FROM public.ecr.aws/dataminded/spark-k8s-glue:v3.0.1-hadoop-3.3.0
 {%- endif %}
 
 ENV PYSPARK_PYTHON python3

--- a/project/spark/{{ cookiecutter.project_name }}/Dockerfile
+++ b/project/spark/{{ cookiecutter.project_name }}/Dockerfile
@@ -1,7 +1,7 @@
 {% if cookiecutter.spark_version == "2.4" -%}
-FROM datamindedbe/spark-k8s-glue:2.4.3-{{ cookiecutter.scala_version }}-hadoop-2.9.2-v3
+FROM public.ecr.aws/dataminded/spark-k8s-glue:2.4.3-{{ cookiecutter.scala_version }}-hadoop-2.9.2-v3
 {%- elif cookiecutter.spark_version == "3.0" -%}
-FROM datamindedbe/spark-k8s-glue:v3.0.1-hadoop-3.3.0
+FROM public.ecr.aws/dataminded/spark-k8s-glue:v3.0.1-hadoop-3.3.0
 {%- endif %}
 
 COPY build/libs/*-all.jar /opt/spark/work-dir/app.jar


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Change to public ecr images

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->
Docker hub has very stringent rate limits. When using these images on an aws account you have no limits.


## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->