### PR TITLE
Convert to new way of import operators for airflow 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ## [Unreleased]
 
 ### features:
-- Update python and pyspark readme to include a section explaining the usage of piptools
+- Update python and pyspark readme to include a section explaining the usage of piptools (@vlieven)
+- Update to the new way of importing operators ahead of the airflow 2.0 upgrade (@stijndehaes)
 
 ## [0.3.3 - 2020-12-30]
 

--- a/project/pyspark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/pyspark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.datafy_spark_plugin import DatafySparkSubmitOperator
+from datafy_airflow_plugins.datafy_spark_plugin.datafy_spark_submit_operator import DatafySparkSubmitOperator
 from datetime import datetime, timedelta
 
 

--- a/project/python/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/python/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.datafy_container_plugin import DatafyContainerOperator
+from datafy_airflow_plugins.datafy_container_plugin.datafy_container_operator import DatafyContainerOperator
 from datetime import datetime, timedelta
 
 

--- a/project/spark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/spark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.datafy_spark_plugin import DatafySparkSubmitOperator
+from datafy_airflow_plugins.datafy_spark_plugin.datafy_spark_submit_operator import DatafySparkSubmitOperator
 from datetime import datetime, timedelta
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Change the way operators are imported

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->
In airflow 2.0 the old way is not supported anymore

## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested in a dag on a productio system