### PR TITLE
Feature/gitignore dbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### features
+
+- Add `.gitignore` file to dbt project template (@jvanbuel)
+
 ## [0.11.0 - 2021-07-07]
 
 ### features

--- a/project/dbt/hooks/post_gen_project.py
+++ b/project/dbt/hooks/post_gen_project.py
@@ -34,7 +34,7 @@ def initialize_dbt_in_dir(dir: str, db_type: str):
     os.chdir(dbt_dir)
     try:
         os.environ["DBT_PROFILES_DIR"] = os.getcwd()
-        import dbt.task.init as init_task  # late import so the environment variable is take into account
+        import dbt.task.init as init_task  # late import so the environment variable is taken into account
         task = init_task.InitTask(args=InitArguments(project_name, db_type), config=None)
         task.run()
         fix_dbt_project()

--- a/project/dbt/{{ cookiecutter.project_name }}/.gitignore
+++ b/project/dbt/{{ cookiecutter.project_name }}/.gitignore
@@ -1,0 +1,125 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a .gitignore to the dbt project template. Also fixed a small typo I happened to notice (which taught me something new about why late imports can be useful, thanks! :)).

## Why are the changes needed?

One of the standard ways of installing dbt is via pip in a virtual environment. As this is also the recommend way in the README.md of the template, it makes sense to add a .gitignore file so that the virtual env is ignored. 

The gitignore file is the same as for the pyspark and python templates, and could be simplified by removing the python build specific stuff (I don't think dbt projects are often distributed as packages?). 
