### PR TITLE
Extend docker ignore to ignore more of the common virtual env locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### features
 - Added streaming support to the spark project (@stijndehaes)
+- Extend docker ignore to ignore more of the common virtual env locations (@stijndehaes)
 
 ## [0.13.0 - 2021-09-27]
 

--- a/project/dbt/{{ cookiecutter.project_name }}/.dockerignore
+++ b/project/dbt/{{ cookiecutter.project_name }}/.dockerignore
@@ -3,7 +3,6 @@ __pycache__
 *.pyo
 *.pyd
 .Python
-env
 pip-log.txt
 pip-delete-this-directory.txt
 .tox
@@ -16,7 +15,15 @@ coverage.xml
 *.log
 .git
 .datafy
-venv
 dags
 Dockerfile
 tests
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/project/pyspark/{{ cookiecutter.project_name }}/.dockerignore
+++ b/project/pyspark/{{ cookiecutter.project_name }}/.dockerignore
@@ -14,9 +14,18 @@ nosetests.xml
 coverage.xml
 *,cover
 *.log
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 .git
 .datafy
-venv
 dags
 Dockerfile
 tests

--- a/project/python/{{ cookiecutter.project_name }}/.dockerignore
+++ b/project/python/{{ cookiecutter.project_name }}/.dockerignore
@@ -3,7 +3,6 @@ __pycache__
 *.pyo
 *.pyd
 .Python
-env
 pip-log.txt
 pip-delete-this-directory.txt
 .tox
@@ -16,7 +15,15 @@ coverage.xml
 *.log
 .git
 .datafy
-venv
 dags
 Dockerfile
 tests
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

- [x] I have updated te CHANGELOG.md

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->
Extend docker ignore to ignore more of the common virtual env locations 

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->
Some people use .env, env, venv, .venv... as a virtual env location

## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->