### PR TITLE
Added the glue workaround from the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### bugfixes
+- Update the spark settings so the aws glue integration works again (@stijndehaes)
+
 ## [0.15.4 - 2022-01-07]
 
 ### bugfixes

--- a/project/pyspark/{{ cookiecutter.project_name }}/src/{{ cookiecutter.module_name }}/common/spark.py
+++ b/project/pyspark/{{ cookiecutter.project_name }}/src/{{ cookiecutter.module_name }}/common/spark.py
@@ -66,6 +66,12 @@ class ClosableSparkSession:
         spark_builder.config("spark.sql.sources.partitionOverwriteMode", "dynamic")
         spark_builder.config("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
 
+        # These values are set because of an issue with the current spark hive, glue connection
+        # For more info see the datafy docs:
+        # https://docs.datafy.cloud/how-to-guides/troubleshooting/spark-pyspark-issues/#glue-orgapachehadoophivemetastoreapiinvalidobjectexception
+        spark_builder.config("spark.sql.hive.metastorePartitionPruning", "false")
+        spark_builder.config("spark.sql.hive.convertMetastoreParquet", "false")
+
         # add other config params
         for key, val in self._spark_config.items():
             spark_builder.config(key, val)

--- a/project/spark/{{ cookiecutter.project_name }}/src/main/scala/{{ cookiecutter.module_name }}/common/SparkSessions.scala
+++ b/project/spark/{{ cookiecutter.project_name }}/src/main/scala/{{ cookiecutter.module_name }}/common/SparkSessions.scala
@@ -15,7 +15,13 @@ trait SparkSessions {
   private val defaultConfiguration: Map[String, String] = Map(
     "fs.s3.impl" -> "org.apache.hadoop.fs.s3a.S3AFileSystem",
     "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
-    "spark.sql.sources.partitionOverwriteMode" -> "dynamic"
+    "spark.sql.sources.partitionOverwriteMode" -> "dynamic",
+
+    // These values are set because of an issue with the current spark hive, glue connection
+    // For more info see the datafy docs:
+    // https://docs.datafy.cloud/how-to-guides/troubleshooting/spark-pyspark-issues/#glue-orgapachehadoophivemetastoreapiinvalidobjectexception
+    "spark.sql.hive.metastorePartitionPruning" -> "false",
+    "spark.sql.hive.convertMetastoreParquet" -> "false"
   )
 
   val spark: SparkSession = {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Don't forget to add your changes to the changelog.md when starting a PR.
-->

- [x] I have updated te CHANGELOG.md

## What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-->

Added some settings to make the aws glue integration work

## Why are the changes needed?
<!--
Please clarify why the changes are needed.
-->
https://docs.datafy.cloud/how-to-guides/troubleshooting/spark-pyspark-issues/#glue-orgapachehadoophivemetastoreapiinvalidobjectexception


## How was this tested?
<!--
If tests were added, say they were added here.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->