### PR TITLE
Use dots instead of underscore in instancetype definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### bugfixes
 - Update the spark settings so the aws glue integration works again (@stijndehaes)
+- Use dots instead of underscores for specifying the Datafy_instance_type. (@nclaeys)
 
 ## [0.15.4 - 2022-01-07]
 

--- a/project/pyspark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/pyspark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -27,8 +27,8 @@ sample_task = DatafySparkSubmitOperatorV2(
     dag=dag,
     task_id="sample",
     num_executors="1",
-    driver_instance_type="mx_small",
-    executor_instance_type="mx_small",
+    driver_instance_type="mx.small",
+    executor_instance_type="mx.small",
     aws_role="{{ cookiecutter.project_name }}-{% raw %}{{ macros.datafy.env() }}{% endraw %}",
     {% if cookiecutter.spark_version == "2.4" -%}
     spark_main_version=2,

--- a/project/python/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/python/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -24,7 +24,7 @@ DatafyContainerOperatorV2(
     task_id="sample",
     cmds=["python"],
     arguments=["-m", "{{ cookiecutter.module_name }}.sample", "{% raw %}--date", "{{ ds }}", "--env", "{{ macros.datafy.env() }}{% endraw %}"],
-    instance_type="mx_micro",
+    instance_type="mx.micro",
 {%- if cookiecutter.datafy_managed_role %}
     aws_role="{{ cookiecutter.project_name }}-{% raw %}{{ macros.datafy.env() }}{% endraw %}",
 {%- endif %}

--- a/project/spark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
+++ b/project/spark/{{ cookiecutter.project_name }}/dags/{{ cookiecutter.project_name }}.py
@@ -26,8 +26,8 @@ sample_task = DatafySparkSubmitOperatorV2(
     dag=dag,
     task_id="sample",
     num_executors="1",
-    driver_instance_type="mx_small",
-    executor_instance_type="mx_small",
+    driver_instance_type="mx.small",
+    executor_instance_type="mx.small",
     {% if cookiecutter.spark_version == "2.4" -%}
     spark_main_version=2,
     {%- elif cookiecutter.spark_version == "3.0" -%}


### PR DESCRIPTION
- [x] I have updated te CHANGELOG.md

## Why are the changes needed?
Consistency in specifying the datafyInstanceType across different type of applications.

## How was this tested?
/