### PR TITLE
Correct cookiecutter.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### bugfixes
+
+- fixed a typo in the cookiecutter.json files such that datafy_managed_role is correctly set.
+
 ## [0.16.1 - 2022-05-10]
 
 ### features

--- a/project/dbt/cookiecutter.json
+++ b/project/dbt/cookiecutter.json
@@ -12,5 +12,5 @@
     "aws",
     "azure"
   ],
-  "datafy_managed_role": "{{ cookiecutter.cloud == 'aws' }}"
+  "datafy_managed_role": true
 }

--- a/project/pyspark/cookiecutter.json
+++ b/project/pyspark/cookiecutter.json
@@ -6,7 +6,7 @@
     "aws",
     "azure"
   ],
-  "datafy_managed_role": "{{ cookiecutter.cloud == 'aws' }}",
+  "datafy_managed_role": true,
   "project_type": [
     "batch",
     "streaming",

--- a/project/python/cookiecutter.json
+++ b/project/python/cookiecutter.json
@@ -7,5 +7,5 @@
     "aws",
     "azure"
   ],
-  "datafy_managed_role": "{{ cookiecutter.cloud == 'aws' }}"
+  "datafy_managed_role": true
 }

--- a/project/spark/cookiecutter.json
+++ b/project/spark/cookiecutter.json
@@ -10,7 +10,7 @@
     "aws",
     "azure"
   ],
-  "datafy_managed_role": "{{ cookiecutter.cloud == 'aws' }}",
+  "datafy_managed_role": true,
   "project_type": [
     "batch",
     "streaming",


### PR DESCRIPTION
Make sure the default cookiecutter.json is correctly filled in with boolean entries for datafy_managed_role.